### PR TITLE
Refactor sandbox structure and task handling

### DIFF
--- a/Intune-App-Sandbox/Configuration/Invoke-IntunewinUtil.ps1
+++ b/Intune-App-Sandbox/Configuration/Invoke-IntunewinUtil.ps1
@@ -2,7 +2,7 @@ param(
     [String]$PackagePath
 )
 
-$SandboxOperatingFolder = 'C:\SandboxEnvironment\bin'
+$SandboxCoreFolder = 'C:\SandboxEnvironment\core'
 $Folder = Get-Item $PackagePath
 
 if ($Folder.FullName -like '*PSADT'){
@@ -10,4 +10,9 @@ if ($Folder.FullName -like '*PSADT'){
 } else{
     $ArgumentList = "-c `"$($Folder.FullName)`" -s `"$($Folder.FullName)\$($Folder.Name).ps1`" -o `"$($Folder.FullName)`" -a `"$($Folder.FullName)`" -q"
 }
-$Packing = Start-Process -FilePath $SandboxOperatingFolder\IntuneWinAppUtil.exe -ArgumentList $ArgumentList -Wait -PassThru -NoNewWindow
+$Packing = Start-Process -FilePath $SandboxCoreFolder\IntuneWinAppUtil.exe -ArgumentList $ArgumentList -Wait -PassThru -NoNewWindow
+$IntunewinFile = Get-ChildItem -Path $Folder.FullName -Filter '*.intunewin' | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+$TargetName = "$($Folder.Name).intunewin"
+if ($IntunewinFile -and $IntunewinFile.Name -ne $TargetName) {
+    Rename-Item -Path $IntunewinFile.FullName -NewName $TargetName -Force
+}

--- a/Intune-App-Sandbox/Configuration/Invoke-Test.ps1
+++ b/Intune-App-Sandbox/Configuration/Invoke-Test.ps1
@@ -6,8 +6,12 @@ param(
 
 $PackageFolderName = Split-Path (Split-Path "$PackagePath" -Parent) -Leaf
 $FileName = (Get-Item $PackagePath).Name
-$SandboxOperatingFolder = 'C:\SandboxEnvironment'
+$SandboxRootFolder = 'C:\SandboxEnvironment'
+$SandboxCoreFolder = "$SandboxRootFolder\core"
+$SandboxAppRoot = "$SandboxRootFolder\apps"
+$AppFolder = Join-Path $SandboxAppRoot $PackageFolderName
 $SandboxFile = "$PackageFolderName.wsb"
+$SandboxFilePath = Join-Path $AppFolder $SandboxFile
 $DetectionScriptFile = "$((Get-Item $PackagePath).Name.Replace('.intunewin',''))_Detection.ps1"
 $FileNameZIP = $($FileName -replace '.intunewin', '.zip')
 if ($FileName -like 'Deploy-Application*'){
@@ -22,12 +26,13 @@ $SandboxTempFolder = 'C:\Temp'
 $SandboxSharedPath = "$SandboxDesktopPath\$PackageFolderName"
 $FullStartupPath = "$SandboxSharedPath\$FileName"
 $FullStartupPath = """$FullStartupPath"""
-$ToastNotificationPath = "$SandboxDesktopPath\bin"
+$ToastNotificationPath = "$SandboxDesktopPath\core"
+$SandboxAppDesktopPath = "$SandboxDesktopPath\$PackageFolderName"
 $ToastTitle = 'Intune App Sandbox'
 #endregion
 
-If (!(Test-Path -Path $SandboxOperatingFolder -PathType Container)) {
-    New-Item -Path $SandboxOperatingFolder -ItemType Directory
+If (!(Test-Path -Path $AppFolder -PathType Container)) {
+    New-Item -Path $AppFolder -ItemType Directory -Force | Out-Null
 }
 Function New-WSB {
     Param
@@ -35,7 +40,7 @@ Function New-WSB {
         [String]$CommandtoRun
     )
 
-    New-Item -Path $SandboxOperatingFolder -Name $SandboxFile -type file -Force | Out-Null
+    New-Item -Path $SandboxFilePath -Type File -Force | Out-Null
     $Config = @"
 <Configuration>
 <VGpu>Enable</VGpu>
@@ -46,7 +51,11 @@ Function New-WSB {
 <ReadOnly>false</ReadOnly>
 </MappedFolder>
 <MappedFolder>
-<HostFolder>C:\SandboxEnvironment\bin</HostFolder>
+<HostFolder>$SandboxCoreFolder</HostFolder>
+<ReadOnly>true</ReadOnly>
+</MappedFolder>
+<MappedFolder>
+<HostFolder>$AppFolder</HostFolder>
 <ReadOnly>true</ReadOnly>
 </MappedFolder>
 </MappedFolders>
@@ -55,7 +64,7 @@ Function New-WSB {
 </LogonCommand>
 </Configuration>
 "@
-    Set-Content -Path "$SandboxOperatingFolder\$SandboxFile" -Value $Config
+    Set-Content -Path $SandboxFilePath -Value $Config
 }
 
 
@@ -66,7 +75,7 @@ If (!(Test-Path -Path $SandboxTempFolder -PathType Container))
 	New-Item -Path $SandboxTempFolder -ItemType Directory
 }
 Copy-Item -Path $FullStartupPath -Destination $SandboxTempFolder
-`$Decoder = Start-Process -FilePath $SandboxDesktopPath\bin\IntuneWinAppUtilDecoder.exe -ArgumentList "$SandboxTempFolder\$FileName /s" -NoNewWindow -PassThru -Wait
+`$Decoder = Start-Process -FilePath $SandboxDesktopPath\core\IntuneWinAppUtilDecoder.exe -ArgumentList "$SandboxTempFolder\$FileName /s" -NoNewWindow -PassThru -Wait
 
 Rename-Item -Path "$SandboxTempFolder\$FileName.decoded" -NewName `'$FileNameZIP`' -Force;
 Expand-Archive -Path "$SandboxTempFolder\$FileNameZIP" -Destination $SandboxTempFolder -Force;
@@ -80,48 +89,48 @@ if(`$$DetectionScript)
     & $SandboxTempFolder\$FileNameRun};`
     New-Item $SandboxTempFolder\`$Lastexitcode.code -force;`
     New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body """Installation completed with code: `$LASTEXITCODE""";`
-    Start-ScheduledTask -TaskName {Detect App}"'
+    Start-ScheduledTask -TaskName {Detect App}; Unregister-ScheduledTask -TaskName {Install App} -Confirm:$false"'
     `$User = "SYSTEM"
     `$Action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument `$TaskActionArgument
-    `$Settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit "01:00" -AllowStartIfOnBatteries
+    `$Settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit "01:00" -AllowStartIfOnBatteries -StartWhenAvailable:`$false
     Register-ScheduledTask -TaskName "Install App" -User `$User -Action `$Action -Settings `$Settings -Force
     `$TaskActionArgument = '-ex bypass "powershell {New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body {Detecting software};`
     & $SandboxTempFolder\$DetectionScriptFile};`
     New-Item $SandboxTempFolder\`$LastExitcode.detectioncode -force;`
     New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body """Detection completed with code: `$LASTEXITCODE"""`
-    if(`$LASTEXITCODE -eq 1){Start-ScheduledTask -TaskName {Install app}}"'
+    if(`$LASTEXITCODE -eq 1){Start-ScheduledTask -TaskName {Install app}}; Unregister-ScheduledTask -TaskName {Detect App} -Confirm:$false"'
     `$Trigger = New-ScheduledTaskTrigger -Once -At `$(Get-Date).AddSeconds(15)
     `$User = "SYSTEM"
     `$Action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument `$TaskActionArgument
-    `$Settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit "01:00" -AllowStartIfOnBatteries
+    `$Settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit "01:00" -AllowStartIfOnBatteries -StartWhenAvailable:`$false
     Register-ScheduledTask -TaskName "Detect App" -Trigger `$Trigger -User `$User -Action `$Action -Settings `$Settings -Force
 
 }else{
     `$TaskActionArgument = '-ex bypass "powershell {New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body {Installing software};`
     & $SandboxTempFolder\$FileNameRun};`
     New-Item $SandboxTempFolder\`$Lastexitcode.code -force;`
-    New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body """Installation completed with code: `$LASTEXITCODE""""'
+    New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body """Installation completed with code: `$LASTEXITCODE"""; Unregister-ScheduledTask -TaskName {Install App} -Confirm:$false"'
     `$Trigger = New-ScheduledTaskTrigger -Once -At `$(Get-Date).AddSeconds(15)
     `$User = "SYSTEM"
     `$Action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument `$TaskActionArgument
-    `$Settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit "01:00" -AllowStartIfOnBatteries
+    `$Settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit "01:00" -AllowStartIfOnBatteries -StartWhenAvailable:`$false
     Register-ScheduledTask -TaskName "Install App" -Trigger `$Trigger -User `$User -Action `$Action -Settings `$Settings -Force
 }
 "@
 
-New-Item -Path $SandboxOperatingFolder\bin -Name "$PackageFolderName`_LogonCommand.ps1" -ItemType File -Value $ScriptBlock -Force | Out-Null
+New-Item -Path $AppFolder -Name "$PackageFolderName`_LogonCommand.ps1" -ItemType File -Value $ScriptBlock -Force | Out-Null
 
 $Scriptblock = @"
 Set-ExecutionPolicy Bypass -Force;
 new-item $PSHOME\Profile.ps1;
-Set-Content -Path $PSHOME\Profile.ps1 -Value '. C:\Users\WDAGUtilityAccount\Desktop\bin\New-ToastNotification.ps1';
-powershell -file '$SandboxDesktopPath\bin\$PackageFolderName`_LogonCommand.ps1'
+Set-Content -Path $PSHOME\Profile.ps1 -Value '. C:\Users\WDAGUtilityAccount\Desktop\core\New-ToastNotification.ps1';
+powershell -file '$SandboxDesktopPath\$PackageFolderName\$PackageFolderName`_LogonCommand.ps1'
 "@
 
-New-Item -Path $SandboxOperatingFolder\bin -Name "$PackageFolderName`_PreLogonCommand.ps1" -ItemType File -Value $ScriptBlock -Force | Out-Null
+New-Item -Path $AppFolder -Name "$PackageFolderName`_PreLogonCommand.ps1" -ItemType File -Value $ScriptBlock -Force | Out-Null
 
-$Startup_Command = "powershell.exe -WindowStyle Hidden -executionpolicy bypass -command $SandboxDesktopPath\bin\$PackageFolderName`_PreLogonCommand.ps1"
+$Startup_Command = "powershell.exe -WindowStyle Hidden -executionpolicy bypass -command $SandboxDesktopPath\$PackageFolderName\$PackageFolderName`_PreLogonCommand.ps1"
 
 New-WSB -CommandtoRun $Startup_Command
 
-Start-Process $SandboxOperatingFolder\$SandboxFile
+Start-Process $SandboxFilePath

--- a/Intune-App-Sandbox/Configuration/Invoke-Winget.ps1
+++ b/Intune-App-Sandbox/Configuration/Invoke-Winget.ps1
@@ -1,0 +1,72 @@
+#params
+param(
+    [String] $PackagePath
+)
+
+$PackageName = (Get-Item $PackagePath).BaseName
+$ConfigFileName = (Get-Item $PackagePath).Name
+$SandboxRootFolder = 'C:\SandboxEnvironment'
+$SandboxCoreFolder = "$SandboxRootFolder\core"
+$SandboxAppRoot = "$SandboxRootFolder\apps"
+$AppFolder = Join-Path $SandboxAppRoot $PackageName
+$SandboxFile = "$PackageName.wsb"
+$SandboxFilePath = Join-Path $AppFolder $SandboxFile
+
+if (!(Test-Path -Path $AppFolder -PathType Container)) {
+    New-Item -Path $AppFolder -ItemType Directory -Force | Out-Null
+}
+
+Copy-Item -Path $PackagePath -Destination $AppFolder -Force
+
+$SandboxDesktopPath = 'C:\Users\WDAGUtilityAccount\Desktop'
+$SandboxAppDesktopPath = "$SandboxDesktopPath\$PackageName"
+$ToastNotificationPath = "$SandboxDesktopPath\core"
+$ToastTitle = 'Intune App Sandbox'
+
+$ScriptBlock = @"
+New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title '$ToastTitle' -Body 'Installing via winget';
+`$proc = Start-Process -FilePath winget.exe -ArgumentList \"import -i $SandboxAppDesktopPath\$ConfigFileName --accept-package-agreements --accept-source-agreements --disable-interactivity\" -PassThru -Wait;
+New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title '$ToastTitle' -Body ('Installation completed with code: ' + `$proc.ExitCode);
+"@
+
+New-Item -Path $AppFolder -Name "$PackageName`_LogonCommand.ps1" -ItemType File -Value $ScriptBlock -Force | Out-Null
+
+$Scriptblock = @"
+Set-ExecutionPolicy Bypass -Force;
+new-item $PSHOME\Profile.ps1;
+Set-Content -Path $PSHOME\Profile.ps1 -Value '. C:\Users\WDAGUtilityAccount\Desktop\core\New-ToastNotification.ps1';
+powershell -file '$SandboxAppDesktopPath\$PackageName`_LogonCommand.ps1'
+"@
+
+New-Item -Path $AppFolder -Name "$PackageName`_PreLogonCommand.ps1" -ItemType File -Value $Scriptblock -Force | Out-Null
+
+$Startup_Command = "powershell.exe -WindowStyle Hidden -executionpolicy bypass -command $SandboxAppDesktopPath\$PackageName`_PreLogonCommand.ps1"
+
+$WSBConfig = @"
+<Configuration>
+<VGpu>Enable</VGpu>
+<Networking>Enable</Networking>
+<MappedFolders>
+<MappedFolder>
+<HostFolder>$((Get-Item $PackagePath).DirectoryName)</HostFolder>
+<ReadOnly>true</ReadOnly>
+</MappedFolder>
+<MappedFolder>
+<HostFolder>$SandboxCoreFolder</HostFolder>
+<ReadOnly>true</ReadOnly>
+</MappedFolder>
+<MappedFolder>
+<HostFolder>$AppFolder</HostFolder>
+<ReadOnly>true</ReadOnly>
+</MappedFolder>
+</MappedFolders>
+<LogonCommand>
+<Command>$Startup_Command</Command>
+</LogonCommand>
+</Configuration>
+"@
+
+Set-Content -Path $SandboxFilePath -Value $WSBConfig
+
+Start-Process $SandboxFilePath
+

--- a/Intune-App-Sandbox/Public/Update-SandboxShell.ps1
+++ b/Intune-App-Sandbox/Public/Update-SandboxShell.ps1
@@ -20,32 +20,51 @@ To correctly create intunewin package, please name parent folder as the same as 
 	}
 	Clear-Host
 	Write-Host 'Thanks for using this tool!' -ForegroundColor Green
-	Write-Host 'Starting update process...' -ForegroundColor Yellow
-	If ((Test-Path -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox\Command')) {
-		If (!(Test-Path -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox with Detection\Command')) {
-			Write-Host 'Context menu item not present.' -ForegroundColor Green
-			New-Item -Path HKCR_SD:\ -Name '.intunewin'
-			New-Item -Path HKCR_SD:\.intunewin -Name 'Shell'
-			Set-Item -Path HKCR_SD:\.intunewin\Shell -Value Open
-			New-Item -Path HKCR_SD:\.intunewin\Shell -Name 'Run test in Sandbox with Detection'
-			New-ItemProperty -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox with Detection' -Name icon -PropertyType 'String' -Value "$SandboxOperatingFolder\sandbox_detection.ico"
-			New-Item -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox with Detection' -Name 'Command'
-			Set-Item -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox with Detection\Command' -Value "C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -command $SandboxOperatingFolder\Invoke-Test.ps1 -PackagePath `"%V`" -DetectionScript `$true"
-		} else {
-			Write-Host 'Context menu item already present!' -ForegroundColor Yellow
-		}
-	}
-	Write-Host 'Checking for operating folder...' -ForegroundColor Yellow -NoNewline
-	$SandboxOperatingFolder = 'C:\SandboxEnvironment\bin'
-	[string] $module = (Get-Command -Name $MyInvocation.MyCommand -All).Source
-	$PathModule = (Get-Module -Name $module.Trim() | Select-Object ModuleBase -First 1).ModuleBase
-	If ((Test-Path -Path $SandboxOperatingFolder -PathType Container)) {
-		Write-Host 'Folder found!' -ForegroundColor Green
-		Write-Host "Copying crucial files to $SandboxOperatingFolder" -ForegroundColor Yellow
-		Copy-Item -Path $PathModule\Configuration\* -Recurse -Destination $SandboxOperatingFolder -Force
-		Write-Host 'Copying helpers files to C:\SandboxEnvironment' -ForegroundColor Yellow
-		Copy-Item -Path $PathModule\Helpers\* -Recurse -Destination 'C:\SandboxEnvironment' -Force
-	}
+        Write-Host 'Starting update process...' -ForegroundColor Yellow
+        $SandboxRootFolder = 'C:\SandboxEnvironment'
+        $SandboxCoreFolder = Join-Path $SandboxRootFolder 'core'
+        If ((Test-Path -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox\Command')) {
+                If (!(Test-Path -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox with Detection\Command')) {
+                        Write-Host 'Context menu item not present.' -ForegroundColor Green
+                        New-Item -Path HKCR_SD:\ -Name '.intunewin'
+                        New-Item -Path HKCR_SD:\.intunewin -Name 'Shell'
+                        Set-Item -Path HKCR_SD:\.intunewin\Shell -Value Open
+                        New-Item -Path HKCR_SD:\.intunewin\Shell -Name 'Run test in Sandbox with Detection'
+                        New-ItemProperty -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox with Detection' -Name icon -PropertyType 'String' -Value "$SandboxCoreFolder\sandbox_detection.ico"
+                        New-Item -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox with Detection' -Name 'Command'
+                        Set-Item -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox with Detection\Command' -Value "C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -command $SandboxCoreFolder\Invoke-Test.ps1 -PackagePath `"%V`" -DetectionScript `$true"
+                } else {
+                        Write-Host 'Context menu item already present!' -ForegroundColor Yellow
+                }
+        }
+        If (!(Test-Path -Path 'HKCR_SD:\.json\Shell\Run test in Sandbox Winget\Command')) {
+                Write-Host 'Context menu item not present.' -ForegroundColor Green
+                New-Item -Path HKCR_SD:\ -Name '.json' -ErrorAction SilentlyContinue
+                New-Item -Path HKCR_SD:\.json -Name 'Shell' -ErrorAction SilentlyContinue
+                Set-Item -Path HKCR_SD:\.json\Shell -Value Open
+                New-Item -Path HKCR_SD:\.json\Shell -Name 'Run test in Sandbox Winget'
+                New-ItemProperty -Path 'HKCR_SD:\.json\Shell\Run test in Sandbox Winget' -Name icon -PropertyType 'String' -Value "$SandboxCoreFolder\sandbox.ico"
+                New-Item -Path 'HKCR_SD:\.json\Shell\Run test in Sandbox Winget' -Name 'Command'
+                Set-Item -Path 'HKCR_SD:\.json\Shell\Run test in Sandbox Winget\Command' -Value "C:\Windows\system32\WindowsPowerShell\v1.0\powershell.exe -executionpolicy bypass -file $SandboxCoreFolder\Invoke-Winget.ps1 -PackagePath `\"%V`\""
+        } else {
+                Write-Host 'Context menu item already present!' -ForegroundColor Yellow
+        }
+        Write-Host 'Checking for operating folders...' -ForegroundColor Yellow -NoNewline
+        $SandboxRootFolder = 'C:\SandboxEnvironment'
+        $SandboxCoreFolder = Join-Path $SandboxRootFolder 'core'
+        $SandboxAppsFolder = Join-Path $SandboxRootFolder 'apps'
+        [string] $module = (Get-Command -Name $MyInvocation.MyCommand -All).Source
+        $PathModule = (Get-Module -Name $module.Trim() | Select-Object ModuleBase -First 1).ModuleBase
+        If ((Test-Path -Path $SandboxCoreFolder -PathType Container)) {
+                Write-Host 'Folder found!' -ForegroundColor Green
+                Write-Host "Copying crucial files to $SandboxCoreFolder" -ForegroundColor Yellow
+                Copy-Item -Path $PathModule\Configuration\* -Recurse -Destination $SandboxCoreFolder -Force
+                Write-Host 'Copying helpers files to $SandboxRootFolder' -ForegroundColor Yellow
+                Copy-Item -Path $PathModule\Helpers\* -Recurse -Destination $SandboxRootFolder -Force
+                if (!(Test-Path -Path $SandboxAppsFolder -PathType Container)) {
+                        New-Item -Path $SandboxAppsFolder -ItemType Directory -Force | Out-Null
+                }
+        }
 	Write-Host 'All done!' -ForegroundColor Green
 	Pause
 }


### PR DESCRIPTION
## Summary
- separate core tool files from per-app data in dedicated folders
- ensure IntuneWin packages adopt the directory name and map app folders in sandbox
- add self-removal for scheduled tasks to prevent reruns after reboot
- add Winget sandbox test script and context menu options

## Testing
- ❌ `pwsh -NoLogo -NoProfile -File tests/Unit.Tests.ps1` (command not found)
- ⚠️ `apt-get update` (403 Forbidden from package repositories)


------
https://chatgpt.com/codex/tasks/task_e_68a983b7c234832e8f0e8ed361168c80