### PR TITLE
Align task names and deduplicate sandbox paths

### DIFF
--- a/Intune-App-Sandbox/Configuration/Invoke-Test.ps1
+++ b/Intune-App-Sandbox/Configuration/Invoke-Test.ps1
@@ -89,32 +89,32 @@ if(`$$DetectionScript)
     & $SandboxTempFolder\$FileNameRun};`
     New-Item $SandboxTempFolder\`$Lastexitcode.code -force;`
     New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body """Installation completed with code: `$LASTEXITCODE""";`
-    Start-ScheduledTask -TaskName {Detect App}; Unregister-ScheduledTask -TaskName {Install App} -Confirm:$false"'
+    Start-ScheduledTask -TaskName {Detect app}; Unregister-ScheduledTask -TaskName {Install app} -Confirm:$false"'
     `$User = "SYSTEM"
     `$Action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument `$TaskActionArgument
     `$Settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit "01:00" -AllowStartIfOnBatteries -StartWhenAvailable:`$false
-    Register-ScheduledTask -TaskName "Install App" -User `$User -Action `$Action -Settings `$Settings -Force
+    Register-ScheduledTask -TaskName "Install app" -User `$User -Action `$Action -Settings `$Settings -Force
     `$TaskActionArgument = '-ex bypass "powershell {New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body {Detecting software};`
     & $SandboxTempFolder\$DetectionScriptFile};`
     New-Item $SandboxTempFolder\`$LastExitcode.detectioncode -force;`
     New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body """Detection completed with code: `$LASTEXITCODE"""`
-    if(`$LASTEXITCODE -eq 1){Start-ScheduledTask -TaskName {Install app}}; Unregister-ScheduledTask -TaskName {Detect App} -Confirm:$false"'
+    if(`$LASTEXITCODE -eq 1){Start-ScheduledTask -TaskName {Install app}}; Unregister-ScheduledTask -TaskName {Detect app} -Confirm:$false"'
     `$Trigger = New-ScheduledTaskTrigger -Once -At `$(Get-Date).AddSeconds(15)
     `$User = "SYSTEM"
     `$Action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument `$TaskActionArgument
     `$Settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit "01:00" -AllowStartIfOnBatteries -StartWhenAvailable:`$false
-    Register-ScheduledTask -TaskName "Detect App" -Trigger `$Trigger -User `$User -Action `$Action -Settings `$Settings -Force
+    Register-ScheduledTask -TaskName "Detect app" -Trigger `$Trigger -User `$User -Action `$Action -Settings `$Settings -Force
 
 }else{
     `$TaskActionArgument = '-ex bypass "powershell {New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body {Installing software};`
     & $SandboxTempFolder\$FileNameRun};`
     New-Item $SandboxTempFolder\`$Lastexitcode.code -force;`
-    New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body """Installation completed with code: `$LASTEXITCODE"""; Unregister-ScheduledTask -TaskName {Install App} -Confirm:$false"'
+    New-ToastNotification -XmlPath $ToastNotificationPath\toast.xml -Title {$ToastTitle} -Body """Installation completed with code: `$LASTEXITCODE"""; Unregister-ScheduledTask -TaskName {Install app} -Confirm:$false"'
     `$Trigger = New-ScheduledTaskTrigger -Once -At `$(Get-Date).AddSeconds(15)
     `$User = "SYSTEM"
     `$Action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument `$TaskActionArgument
     `$Settings = New-ScheduledTaskSettingsSet -ExecutionTimeLimit "01:00" -AllowStartIfOnBatteries -StartWhenAvailable:`$false
-    Register-ScheduledTask -TaskName "Install App" -Trigger `$Trigger -User `$User -Action `$Action -Settings `$Settings -Force
+    Register-ScheduledTask -TaskName "Install app" -Trigger `$Trigger -User `$User -Action `$Action -Settings `$Settings -Force
 }
 "@
 

--- a/Intune-App-Sandbox/Public/Update-SandboxShell.ps1
+++ b/Intune-App-Sandbox/Public/Update-SandboxShell.ps1
@@ -23,6 +23,7 @@ To correctly create intunewin package, please name parent folder as the same as 
         Write-Host 'Starting update process...' -ForegroundColor Yellow
         $SandboxRootFolder = 'C:\SandboxEnvironment'
         $SandboxCoreFolder = Join-Path $SandboxRootFolder 'core'
+        $SandboxAppsFolder = Join-Path $SandboxRootFolder 'apps'
         If ((Test-Path -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox\Command')) {
                 If (!(Test-Path -Path 'HKCR_SD:\.intunewin\Shell\Run test in Sandbox with Detection\Command')) {
                         Write-Host 'Context menu item not present.' -ForegroundColor Green
@@ -50,9 +51,6 @@ To correctly create intunewin package, please name parent folder as the same as 
                 Write-Host 'Context menu item already present!' -ForegroundColor Yellow
         }
         Write-Host 'Checking for operating folders...' -ForegroundColor Yellow -NoNewline
-        $SandboxRootFolder = 'C:\SandboxEnvironment'
-        $SandboxCoreFolder = Join-Path $SandboxRootFolder 'core'
-        $SandboxAppsFolder = Join-Path $SandboxRootFolder 'apps'
         [string] $module = (Get-Command -Name $MyInvocation.MyCommand -All).Source
         $PathModule = (Get-Module -Name $module.Trim() | Select-Object ModuleBase -First 1).ModuleBase
         If ((Test-Path -Path $SandboxCoreFolder -PathType Container)) {


### PR DESCRIPTION
## Summary
- define the sandbox folder variables once at the start of `Update-SandboxShell` and reuse them later in the function
- standardize the scheduled task names in `Invoke-Test` to use the same casing when registering, starting, and unregistering tasks

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68c889f1acbc832ea506fec2b6a1d02b